### PR TITLE
Add patch to remove unused Qt dependency from vtkPVVTKExtensionsDefaults

### DIFF
--- a/buildscript
+++ b/buildscript
@@ -87,6 +87,7 @@ git apply ${SCRIPT_DIR}/patches/1565.diff
 git apply ${SCRIPT_DIR}/patches/1850.diff
 git apply ${SCRIPT_DIR}/patches/1866.diff
 git apply ${SCRIPT_DIR}/patches/1882.diff
+git apply ${SCRIPT_DIR}/patches/remove-vtkguisupportqt-dep.diff
 if [[ "$ON_OSX" == false ]]; then
   git revert a99ea990a1bc34f072b50f794778e93595bcda8f
 fi

--- a/buildscript.bat
+++ b/buildscript.bat
@@ -81,6 +81,7 @@ cd %SRC_DIR%\%PARAVIEW_SRC%
 "%GitCmd%" apply --ignore-whitespace %SCRIPT_DIR%\patches\1850.diff
 "%GitCmd%" apply --ignore-whitespace %SCRIPT_DIR%\patches\1866.diff
 "%GitCmd%" apply --ignore-whitespace %SCRIPT_DIR%\patches\1882.diff
+"%GitCmd%" apply --ignore-whitespace %SCRIPT_DIR%\patches\remove-vtkguisupportqt-dep.diff
 cd %SRC_DIR%\%PARAVIEW_SRC%\VTK
 "%GitCmd%" config user.name "Bob T. Builder"
 "%GitCmd%" config user.email "builder@ornl.gov"

--- a/patches/remove-vtkguisupportqt-dep.diff
+++ b/patches/remove-vtkguisupportqt-dep.diff
@@ -1,0 +1,29 @@
+diff --git a/Catalyst/Editions/Rendering-Base/ParaViewCore/VTKExtensions/Rendering/module.cmake b/Catalyst/Editions/Rendering-Base/ParaViewCore/VTKExtensions/Rendering/module.cmake
+index 44a7d06..5bd4a8f 100644
+--- a/Catalyst/Editions/Rendering-Base/ParaViewCore/VTKExtensions/Rendering/module.cmake
++++ b/Catalyst/Editions/Rendering-Base/ParaViewCore/VTKExtensions/Rendering/module.cmake
+@@ -13,9 +13,6 @@ if(PARAVIEW_ENABLE_PYTHON)
+   #list(APPEND __dependencies vtkRenderingMatplotlib)
+ endif()
+
+-if (PARAVIEW_ENABLE_QT_SUPPORT)
+-  list(APPEND __dependencies vtkGUISupportQt)
+-endif()
+ if("${VTK_RENDERING_BACKEND}" STREQUAL "OpenGL")
+   #list(APPEND __dependencies vtkRenderingLIC)
+   if (PARAVIEW_USE_MPI)
+diff --git a/ParaViewCore/VTKExtensions/Rendering/module.cmake b/ParaViewCore/VTKExtensions/Rendering/module.cmake
+index f92b157..942c6ea 100644
+--- a/ParaViewCore/VTKExtensions/Rendering/module.cmake
++++ b/ParaViewCore/VTKExtensions/Rendering/module.cmake
+@@ -13,10 +13,6 @@ if(PARAVIEW_ENABLE_MATPLOTLIB)
+   list(APPEND __dependencies vtkRenderingMatplotlib)
+ endif()
+
+-if (PARAVIEW_ENABLE_QT_SUPPORT)
+-  list(APPEND __dependencies vtkGUISupportQt)
+-endif()
+-
+ if("${VTK_RENDERING_BACKEND}" STREQUAL "OpenGL")
+   list(APPEND __dependencies vtkRenderingLIC)
+   if (PARAVIEW_USE_MPI)


### PR DESCRIPTION
`vtkPVVTKExtensionsDefaults` depends on `vtkPVVTKExtensionsRendering`, which in turn depends on `vtkGUISupportQt` but from `ldd --unused` this library is not used at all. It does however cause issues in our combined Qt4/Qt5 build.

This additional patch removes the dependency from the library.

I tested this on RHEL7 by rebuilding ParaView with this patch and running all of the Vates unit tests. 
